### PR TITLE
Mark package as development dependency

### DIFF
--- a/ClrHeapAllocationsAnalyzer/Diagnostic.nuspec
+++ b/ClrHeapAllocationsAnalyzer/Diagnostic.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"?>
 <package>
-    <metadata>
+    <metadata minClientVersion="2.8">
         <id>ClrHeapAllocationAnalyzer</id>
         <version>1.0.0.6</version>
         <title>Clr C# Heap Allocation Analyzer</title>
@@ -23,6 +23,7 @@
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System" targetFramework="" />
         </frameworkAssemblies>
+        <developmentDependency>true</developmentDependency>
     </metadata>
     <files>
         <file src="*.dll" target="tools\analyzers\" exclude="**\Microsoft.CodeAnalysis.*;**\System.Collections.Immutable.*;**\System.Reflection.Metadata.*" />


### PR DESCRIPTION
This will cause the package to be excluded from the dependency list when the referencing project itself is later packaged.
http://docs.nuget.org/Release-Notes/NuGet-2.7#development-only-dependencies