### PR TITLE
Make the nuget package work on .NETCore

### DIFF
--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -108,10 +108,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.5\Microsoft.Portable.CSharp.targets" />
   <Target Name="AfterBuild">
-    <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
-      <Output TaskParameter="Assemblies" ItemName="AnalyzerAssemblyInfo" />
-    </GetAssemblyIdentity>
-    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe&quot; pack Diagnostic.nuspec -NoPackageAnalysis -Version %(AnalyzerAssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
+    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe&quot; pack Diagnostic.nuspec -NoPackageAnalysis -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>

--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -107,8 +107,12 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.5\Microsoft.Portable.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe" pack Diagnostic.nuspec -NoPackageAnalysis -OutputDirectory .</PostBuildEvent>
-    <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
-  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
+      <Output TaskParameter="Assemblies" ItemName="AnalyzerAssemblyInfo" />
+    </GetAssemblyIdentity>
+    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe&quot; pack Diagnostic.nuspec -NoPackageAnalysis -Version %(AnalyzerAssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+  </Target>
 </Project>

--- a/ClrHeapAllocationsAnalyzer/Diagnostic.nuspec
+++ b/ClrHeapAllocationsAnalyzer/Diagnostic.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata minClientVersion="2.8">
         <id>ClrHeapAllocationAnalyzer</id>
-        <version>1.0.0.7</version>
+        <version>1.0.0.8</version>
         <title>Clr C# Heap Allocation Analyzer</title>
         <authors>mjsabby</authors>
         <owners>mjsabby</owners>

--- a/ClrHeapAllocationsAnalyzer/Diagnostic.nuspec
+++ b/ClrHeapAllocationsAnalyzer/Diagnostic.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0"?>
-<package>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata minClientVersion="2.8">
         <id>ClrHeapAllocationAnalyzer</id>
         <version>1.0.0.7</version>


### PR DESCRIPTION
(1) At the moment the version 1.0.0.6 up on NuGet has the wrong directory structure for being consumed by .NETCore projects. But the most recent source code on github builds 1.0.0.7 with the correct directory structure. So this change has no effect on the directory structure, and doesn't need to.

(2) The most recent 1.0.0.7 source code on github omits the xsd: declaration in the nuspec file. This omission causes .NETCore projects to say "missing metadata" when they attempt to reference the package. I have restored this.

(3) I also just copied+pasted the NuGet.exe invocation from the newest RoslynSDK File>New>Analyzer, over into this one. There aren't material differences. I just figured it was good to stay up to date.

(4) I bumped up the version number to 1.0.0.8


I tested this new 1.0.08 version of the NuGet package on a Desktop console app, in a UWP app, and in a .NETCore console app. It worked fine in all three of them. (the existing 1.0.0.6 version currently up on NuGet fails to work with the latter two).